### PR TITLE
Fix: Inner container height

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,14 @@
   <head>
     <style>
 
+      html,
+      body,
+      #content {
+        height: 99.98%; 
+        width: 99.98%; 
+        display: block;
+      }
+
       #container {
         font-family: 'Segoe UI',wf_segoe-ui_normal,helvetica,arial,sans-serif;
         height: 95%; 


### PR DESCRIPTION
Even though iframe height is set explicitly, the html height needs to be set for the report to load properly. Had removed it in previous PR as it was working fine in local browser. Added it back and tested. It is working fine now.

https://kgkrishnalmt.github.io/InforiverWebReports/?name=amazon&read-mode=true